### PR TITLE
Handle a few missing paren warnings

### DIFF
--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -211,6 +211,6 @@ defmodule Ueberauth.Strategy.Github do
   end
 
   defp option(conn, key) do
-    Map.get(options(conn), key, Map.get(default_options, key))
+    Map.get(options(conn), key, Map.get(default_options(), key))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,15 +7,15 @@ defmodule UeberauthGithub.Mixfile do
     [app: :ueberauth_github,
      version: @version,
      name: "Ueberauth Github",
-     package: package,
+     package: package(),
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      source_url: "https://github.com/ueberauth/ueberauth_github",
      homepage_url: "https://github.com/ueberauth/ueberauth_github",
-     description: description,
-     deps: deps,
-     docs: docs]
+     description: description(),
+     deps: deps(),
+     docs: docs()]
   end
 
   def application do


### PR DESCRIPTION
Hey, I thought this small PR might help get ready for Elixir 1.4. 

Here is the warning 1.4 emits. 

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
```