### PR TITLE
Fix Elixir 1.4 warning

### DIFF
--- a/lib/ueberauth/strategy/github/oauth.ex
+++ b/lib/ueberauth/strategy/github/oauth.ex
@@ -44,7 +44,7 @@ defmodule Ueberauth.Strategy.Github.OAuth do
 
   def get(token, url, headers \\ [], opts \\ []) do
     client([token: token])
-    |> put_param("client_secret", client.client_secret)
+    |> put_param("client_secret", client().client_secret)
     |> OAuth2.Client.get(url, headers, opts)
   end
 


### PR DESCRIPTION
Compiling generates this warning:

```
==> ueberauth_github
Compiling 3 files (.ex)
warning: variable "client" does not exist and is being expanded to "client()", please use parentheses to remove the ambiguity or change the variable name
  lib/ueberauth/strategy/github/oauth.ex:47

Generated ueberauth_github app
```