### PR TITLE
Fix typo in documentation

### DIFF
--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -66,7 +66,7 @@ defmodule Ueberauth.Strategy.Github do
           github: { Ueberauth.Strategy.Github, [default_scope: "user,public_repo"] }
         ]
 
-  Deafult is "user,public_repo"
+  Default is "user,public_repo"
   """
   use Ueberauth.Strategy, uid_field: :login,
                           default_scope: "user,public_repo",


### PR DESCRIPTION
This PR just changes a trivial typo in the `Ueberauth.Strategy.Github` `@moduledoc`.