### PR TITLE
Improve configuration error messages

### DIFF
--- a/lib/ueberauth/strategy/github/oauth.ex
+++ b/lib/ueberauth/strategy/github/oauth.ex
@@ -28,7 +28,8 @@ defmodule Ueberauth.Strategy.Github.OAuth do
   These options are only useful for usage outside the normal callback phase of Ueberauth.
   """
   def client(opts \\ []) do
-    config = :ueberauth
+    config =
+    :ueberauth
     |> Application.fetch_env!(Ueberauth.Strategy.Github.OAuth)
     |> check_config_key_exists(:client_id)
     |> check_config_key_exists(:client_secret)

--- a/lib/ueberauth/strategy/github/oauth.ex
+++ b/lib/ueberauth/strategy/github/oauth.ex
@@ -28,7 +28,7 @@ defmodule Ueberauth.Strategy.Github.OAuth do
   These options are only useful for usage outside the normal callback phase of Ueberauth.
   """
   def client(opts \\ []) do
-    config = Application.get_env(:ueberauth, Ueberauth.Strategy.Github.OAuth)
+    config = Application.fetch_env!(:ueberauth, Ueberauth.Strategy.Github.OAuth)
     client_opts =
       @defaults
       |> Keyword.merge(config)

--- a/lib/ueberauth/strategy/github/oauth.ex
+++ b/lib/ueberauth/strategy/github/oauth.ex
@@ -28,7 +28,11 @@ defmodule Ueberauth.Strategy.Github.OAuth do
   These options are only useful for usage outside the normal callback phase of Ueberauth.
   """
   def client(opts \\ []) do
-    config = Application.fetch_env!(:ueberauth, Ueberauth.Strategy.Github.OAuth)
+    config = :ueberauth
+    |> Application.fetch_env!(Ueberauth.Strategy.Github.OAuth)
+    |> check_config_key_exists(:client_id)
+    |> check_config_key_exists(:client_secret)
+
     client_opts =
       @defaults
       |> Keyword.merge(config)
@@ -72,5 +76,15 @@ defmodule Ueberauth.Strategy.Github.OAuth do
     |> put_param("client_secret", client.client_secret)
     |> put_header("Accept", "application/json")
     |> OAuth2.Strategy.AuthCode.get_token(params, headers)
+  end
+
+  defp check_config_key_exists(config, key) when is_list(config) do
+    unless Keyword.has_key?(config, key) do
+      raise "#{inspect (key)} missing from config :ueberauth, Ueberauth.Strategy.Github"
+    end
+    config
+  end
+  defp check_config_key_exists(_, _) do
+    raise "Config :ueberauth, Ueberauth.Strategy.Github is not a keyword list, as expected"
   end
 end


### PR DESCRIPTION
We use this strategy quite a lot, and for some reason it's quite common for people to mess up this configuration. This improves the chances of getting a meaningful error message if you get the configuration wrong.

The PR is split into two commits. The first just lets you know if you've completely missed out `config :ueberauth, Ueberauth.Strategy.Github.OAuth`. The second also checks for the presence of the `client_id` and `client_secret` keys.
