### PR TITLE
Allow users to configure whether they want to send the `redirect_uri` to GitHub or not. It defaults to true.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
+It is also possible to disable the sending of the `redirect_uri` to GitHub. This is particularly useful
+when your production application sits behind a proxy that handles SSL connections. In this case,
+the `redirect_uri` sent by `Ueberauth` will start with `http` instead of `https`, and if you configured
+your GitHub OAuth application's callback URL to use HTTPS, GitHub will throw an `uri_missmatch` error.
+
+To prevent `Ueberauth` from sending the `redirect_uri`, you should add the following to your configuration:
+
+```elixir
+config :ueberauth, Ueberauth,
+  providers: [
+    github: {Ueberauth.Strategy.Github, [send_redirect_uri: false]}
+  ]
+```
+
 ## License
 
 Please see [LICENSE](https://github.com/ueberauth/ueberauth_github/blob/master/LICENSE) for licensing details.

--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -87,7 +87,14 @@ defmodule Ueberauth.Strategy.Github do
   """
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
-    opts = [redirect_uri: callback_url(conn), scope: scopes]
+    send_redirect_uri = Keyword.get(options(conn), :send_redirect_uri, true)
+
+    opts =
+      if send_redirect_uri do
+        [redirect_uri: callback_url(conn), scope: scopes]
+      else
+        [scope: scopes]
+      end
 
     opts =
       if conn.params["state"], do: Keyword.put(opts, :state, conn.params["state"]), else: opts


### PR DESCRIPTION
- GitHub already has the `redirect_uri` in the OAuth app settings, and if there is a missmatch, it will error out.
- This happens on prod environments where ngnix is proxying SSL connections. `callback_url` returns the http address, and not https, which causes the error.
- Changing the `callback_url` settings does not help.

To set this use the following snippet:

```elixir
config :ueberauth, Ueberauth,
  providers: [
    github: {
      Ueberauth.Strategy.Github, [
        default_scope: "user,repo",
        send_redirect_uri: false
      ]
    }
  ]
```
