### PR TITLE
Update README to identify read-only options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Or with options:
 
     /auth/github?scope=user,public_repo
 
-By default the requested scope is "user,public\_repo". Scope can be configured either explicitly as a `scope` query value on the request path or in your configuration:
+By default the requested scope is "user,public\_repo". This provides both read and write access to the GitHub user profile details and public repos. For a read-only scope, either use "user:email" or an empty scope "". See more at [GitHub's OAuth Documentation](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/). Scope can be configured either explicitly as a `scope` query value on the request path or in your configuration:
 
 ```elixir
 config :ueberauth, Ueberauth,


### PR DESCRIPTION
Addresses issue #31 by identifying read-only scope options in the README.

Tested on my end, and both `default_scope: 'user:email'` and `default_scope: ''` work just fine.