### PR TITLE
Adding image: to user %Info

### DIFF
--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -172,6 +172,7 @@ defmodule Ueberauth.Strategy.Github do
       nickname: user["login"],
       email: user["email"] || Enum.find(user["emails"] || [], &(&1["primary"]))["email"],
       location: user["location"],
+      image: user["avatar_url"],      
       urls: %{
         followers_url: user["followers_url"],
         avatar_url: user["avatar_url"],


### PR DESCRIPTION
Pretty much all other Ueberauth strategies use `image:` for purposes of the user's avatar. So I suggest doing the same with the GitHub strategy, so as to avoid needing to customize the templating for this strategy relative to the other in order to display this avatar

Currently, when a developer is trying to display the user's avatar in a template, they need to create a tweak / custom function in order to access the github avatar with `auth.info.urls.avatar_url` instead of just `auth.info.image`.

As an example of what I mean, see these other strategies:

LINE 111 in https://github.com/ueberauth/ueberauth_facebook/blob/master/lib/ueberauth/strategy/facebook.ex

LINE 109 in https://github.com/fajarmf/ueberauth_linkedin/blob/master/lib/ueberauth/strategy/linkedin.ex

LINE 76 https://github.com/ueberauth/ueberauth_twitter/blob/master/lib/ueberauth/strategy/twitter.ex

I came across this in the course of working on an updated step-by-step guide, screencast and sample app that I'm creating to walk through implementing Ueberauth + Guardian in Phx 1.3.