### PR TITLE
Added description field from bio.

### DIFF
--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -165,10 +165,11 @@ defmodule Ueberauth.Strategy.Github do
 
     %Info{
       name: user["name"],
+      description: user["bio"],
       nickname: user["login"],
       email: fetch_email!(user),
       location: user["location"],
-      image: user["avatar_url"],      
+      image: user["avatar_url"],
       urls: %{
         followers_url: user["followers_url"],
         avatar_url: user["avatar_url"],


### PR DESCRIPTION
The bio field is returned from https://developer.github.com/v3/users/#get-a-single-user and from what I can tell isn't set to the description field available in Info.