### PR TITLE
Add ability to read GitHub client credentials at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@
       client_secret: System.get_env("GITHUB_CLIENT_SECRET")
     ```
 
+    Or, to read the client credentials at runtime:
+
+    ```elixir
+    config :ueberauth, Ueberauth.Strategy.Github.OAuth,
+      client_id: {:system, "GITHUB_CLIENT_ID"},
+      client_secret: {:system, "GITHUB_CLIENT_SECRET"}
+    ```
+
 1.  Include the Überauth plug in your controller:
 
     ```elixir

--- a/lib/ueberauth/strategy/github/oauth.ex
+++ b/lib/ueberauth/strategy/github/oauth.ex
@@ -31,8 +31,8 @@ defmodule Ueberauth.Strategy.Github.OAuth do
     config =
     :ueberauth
     |> Application.fetch_env!(Ueberauth.Strategy.Github.OAuth)
-    |> check_config_key_exists(:client_id)
-    |> check_config_key_exists(:client_secret)
+    |> check_credential(:client_id)
+    |> check_credential(:client_secret)
 
     client_opts =
       @defaults
@@ -77,6 +77,22 @@ defmodule Ueberauth.Strategy.Github.OAuth do
     |> put_param("client_secret", client.client_secret)
     |> put_header("Accept", "application/json")
     |> OAuth2.Strategy.AuthCode.get_token(params, headers)
+  end
+
+  defp check_credential(config, key) do
+    check_config_key_exists(config, key)
+
+    case Keyword.get(config, key) do
+      value when is_binary(value) ->
+        config
+      {:system, env_key} ->
+        case System.get_env(env_key) do
+          nil ->
+            raise "#{inspect (env_key)} missing from environment, expected in config :ueberauth, Ueberauth.Strategy.Github"
+          value ->
+            Keyword.put(config, key, value)
+        end
+    end
   end
 
   defp check_config_key_exists(config, key) when is_list(config) do


### PR DESCRIPTION
This pull request adds the ability to read GitHub client credentials at runtime, rather than only at compile time.

Doing this allows for a couple of useful things:

1. Rolling client credentials without a deploy.
2. Promoting compiled apps directly from staging to production.

The existing configuration works, but users can now configure like so in order to have credentials read at runtime:

```elixir
config :ueberauth, Ueberauth.Strategy.Github.OAuth,
  client_id: {:system, "GITHUB_CLIENT_ID"},
  client_secret: {:system, "GITHUB_CLIENT_SECRET"}
```