### PR TITLE
Add unit test support

### DIFF
--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -104,6 +104,11 @@ defmodule Ueberauth.Strategy.Github do
   end
 
   @doc """
+  Support unit test
+  """
+  def handle_callback!(%Plug.Conn{params: %{"code" => "test_code"}} = conn), do: conn
+
+  @doc """
   Handles the callback from Github. When there is a failure from Github the failure is included in the
   `ueberauth_failure` struct. Otherwise the information returned from Github is returned in the `Ueberauth.Auth` struct.
   """

--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -104,7 +104,7 @@ defmodule Ueberauth.Strategy.Github do
   end
 
   @doc """
-  Support unit test
+  Enable callback with code=test_code for unit test support only.
 
   Authorization can be mock in unit test.
   Example:
@@ -123,7 +123,16 @@ defmodule Ueberauth.Strategy.Github do
     end
   end
   """
-  def handle_callback!(%Plug.Conn{params: %{"code" => "test_code"}} = conn), do: conn
+  def handle_callback!(%Plug.Conn{params: %{"code" => "test_code"}} = conn) do
+    case Mix.env() do
+      :test ->
+        conn
+      _ ->
+        conn
+        |> Map.put(:assigns, Map.delete(conn.assigns, :ueberauth_auth))
+        |> set_errors!([error("invalid_code", "test_code is for test only.")])
+    end
+  end
 
   @doc """
   Handles the callback from Github. When there is a failure from Github the failure is included in the

--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -105,6 +105,23 @@ defmodule Ueberauth.Strategy.Github do
 
   @doc """
   Support unit test
+
+  Authorization can be mock in unit test.
+  Example:
+
+  describe "new github authentication" do
+    test "create new user", %{conn: conn} do
+      assert Accounts.find_authentication(@github_params.uid) == nil
+
+      conn =
+        conn
+        |> assign(:ueberauth_auth, @github_params)
+        |> get(auth_path(conn, :callback, :github), %{"code" => "test_code"})
+
+      assert html_response(conn, 302)
+      assert Accounts.find_authentication(@github_params.uid) != nil
+    end
+  end
   """
   def handle_callback!(%Plug.Conn{params: %{"code" => "test_code"}} = conn), do: conn
 


### PR DESCRIPTION
  Enable callback with code=test_code for unit test support only.

  Authorization can be mock in unit test.
  Example:

  ```elixir
  describe "new github authentication" do
    test "create new user", %{conn: conn} do
      assert Accounts.find_authentication(@github_params.uid) == nil

      conn =
        conn
        |> assign(:ueberauth_auth, @github_params)
        |> get(auth_path(conn, :callback, :github), %{"code" => "test_code"})

      assert html_response(conn, 302)
      assert Accounts.find_authentication(@github_params.uid) != nil
    end
  end
  ```