### PR TITLE
Removing unnecessary setup step for "applications"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,6 @@
     end
     ```
 
-1. Add the strategy to your applications:
-
-    ```elixir
-    def application do
-      [applications: [:ueberauth_github]]
-    end
-    ```
-
 1. Add GitHub to your Überauth configuration:
 
     ```elixir


### PR DESCRIPTION
Removing the unnecessary setup step for "applications", because since Elixir 1.4 it is [inferred automatically](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference).

Other repos such ueberauth, guardian, etc also do not contains this step anymore.