### PR TITLE
update state param handling & ueberauth to 0.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Ueberauth.Github.Mixfile do
   defp deps do
     [
       {:oauth2, "~> 1.0 or ~> 2.0"},
-      {:ueberauth, "~> 0.6.0"},
+      {:ueberauth, "~> 0.7.0"},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
Hi Ueberauth team,

First, kudos for creating & maintaining `ueberauth`. It's beautifully documented and easy to work with. :muscle: 

I started using `ueberauth_github` in my pet project and wanted to use newest shiniest versions of all deps, however it locks `ueberauth` on `~> 0.6.0`. I thought it's good opportunity to learn how it looks & works under the hood and here is a result of this.

As of `0.7`, `ueberauth` generates random `state` during request phase, stores it internally, and later uses it to compare with state received from Github in callback phase.

```ex
  defp state_param_matches?(conn) do
    param_cookie = conn.params["state"]
    not is_nil(param_cookie) and param_cookie == get_state_cookie(conn)
  end
```

It's a problem because `ueberauth_github` implementation would send different (possibly empty) state to Github servers and comparison in callback phase would always fail. To fix it I used `with_state_param/2` helper coming from core lib to get correct state value.

:warning: It's possibly a breaking change because if the state param was used to implement manual validation pre 0.7. This validation will stop working, however it is no longer needed and can be deleted because it's built-in to core as of v0.7.

If clients didn't implement manual validation it's not a breaking change.

I tested this code on my pet project I mentioned earlier.

Hope you find this PR useful :upside_down_face: 