### PR TITLE
add user agent header

### DIFF
--- a/lib/ueberauth/strategy/github/oauth.ex
+++ b/lib/ueberauth/strategy/github/oauth.ex
@@ -16,7 +16,8 @@ defmodule Ueberauth.Strategy.Github.OAuth do
     strategy: __MODULE__,
     site: "https://api.github.com",
     authorize_url: "https://github.com/login/oauth/authorize",
-    token_url: "https://github.com/login/oauth/access_token"
+    token_url: "https://github.com/login/oauth/access_token",
+    headers: [{"user-agent", "ueberauth-github"}]
   ]
 
   @doc """


### PR DESCRIPTION
Fixes: https://github.com/ueberauth/ueberauth_github/issues/73

The GitHub strategy is failing with an error stating that the GitHub API requires a `User-Agent` header. Here we add a default `User-Agent` header to the client options.