### PR TITLE
Conditionally fetch email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v8.8.2
+## v0.8.3
 
-* add user agent header [#76](https://github.com/ueberauth/ueberauth_github/pull/76)
+* Fix empty scope not allowing to proceed with an expected missing email [#77](https://github.com/ueberauth/ueberauth_github/issues/77)
+
+## v0.8.2
+
+* Add user agent header [#76](https://github.com/ueberauth/ueberauth_github/pull/76)
 * Update version in README [#70](https://github.com/ueberauth/ueberauth_github/pull/70)
 * Fix typos [#72](https://github.com/ueberauth/ueberauth_github/pull/72)
 * Relax version constraint on ueberauth [#71](https://github.com/ueberauth/ueberauth_github/pull/71)

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Or with options:
 
     /auth/github?scope=user,public_repo
 
-By default the requested scope is "user,public\_repo". This provides both read
+By default the requested scope is `"user,public\_repo"`. This provides both read
 and write access to the GitHub user profile details and public repos. For a
-read-only scope, either use "user:email" or an empty scope "". See more at
-[GitHub's OAuth Documentation](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).
+read-only scope, either use `"user:email"` or an empty scope `""`. Empty scope
+will only request minimum public information which even excludes user's email address
+which results in a `nil` for `email` inside returned `%Ueberauth.Auth.Info{}`.
+See more at [GitHub's OAuth Documentation](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/).
 
 Scope can be configured either explicitly as a `scope` query value on the
 request path or in your configuration:

--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -219,26 +219,24 @@ defmodule Ueberauth.Strategy.Github do
     conn.private.github_user[field]
   end
 
-  defp maybe_fetch_email(user, allow_private_emails) do
-    user["email"] ||
-      get_primary_email!(user) ||
-      get_private_email!(user, allow_private_emails)
-  end
-
   defp fetch_email!(user, allow_private_emails) do
-    user["email"] ||
-      get_primary_email!(user) ||
-      get_private_email!(user, allow_private_emails) ||
+    maybe_fetch_email(user, allow_private_emails) ||
       raise "Unable to access the user's email address"
   end
 
-  defp get_primary_email!(user) do
+  defp maybe_fetch_email(user, allow_private_emails) do
+    user["email"] ||
+      maybe_get_primary_email(user) ||
+      maybe_get_private_email(user, allow_private_emails)
+  end
+
+  defp maybe_get_primary_email(user) do
     if user["emails"] && Enum.count(user["emails"]) > 0 do
       Enum.find(user["emails"], & &1["primary"])["email"]
     end
   end
 
-  defp get_private_email!(user, allow_private_emails) do
+  defp maybe_get_private_email(user, allow_private_emails) do
     if allow_private_emails do
       "#{user["id"]}+#{user["login"]}@users.noreply.github.com"
     end

--- a/lib/ueberauth/strategy/github.ex
+++ b/lib/ueberauth/strategy/github.ex
@@ -175,7 +175,7 @@ defmodule Ueberauth.Strategy.Github do
       name: user["name"],
       description: user["bio"],
       nickname: user["login"],
-      email: fetch_email!(user, allow_private_emails),
+      email: maybe_fetch_email(user, allow_private_emails),
       location: user["location"],
       image: user["avatar_url"],
       urls: %{
@@ -217,6 +217,12 @@ defmodule Ueberauth.Strategy.Github do
 
   defp fetch_uid(field, conn) do
     conn.private.github_user[field]
+  end
+
+  defp maybe_fetch_email(user, allow_private_emails) do
+    user["email"] ||
+      get_primary_email!(user) ||
+      get_private_email!(user, allow_private_emails)
   end
 
   defp fetch_email!(user, allow_private_emails) do


### PR DESCRIPTION
Not a very sophisticated approach to simply ignore email. But I couldn't discover any immediate punishment and it seems to simply return a valid `%Ueberauth.Auth` struct with `nil` for `email` field along with other `nil` for a bunch of other data that is beyond the scope.